### PR TITLE
Create ohmmeter.ino

### DIFF
--- a/ohmmeter.ino
+++ b/ohmmeter.ino
@@ -1,0 +1,30 @@
+#include <LiquidCrystal.h>        // include the lcd library code
+
+LiquidCrystal lcd(7, 8, 9, 10, 11, 12);   // initialize the library with the numbers of the interface pins
+int VpPin = A0;
+
+float Vin = 5;
+float Vout;
+float Rknown = 3900;
+float Runkown;
+
+void setup() {
+  Serial.begin(9600);
+  
+  lcd.begin(16, 2);               // set up the LCD's number of columns and rows:
+}
+
+void loop() {
+  lcd.clear();
+  Vout = analogRead(lightPin) * (Vin / 1023);
+  lcd.setCursor(0, 1);
+  lcd.print("Vout = ");
+  lcd.print(Vout);
+  
+  Runkown = (Vin * Rknown) / Vout - Rknown;
+  lcd.setCursor(0,0);
+  lcd.print("R = ");
+  lcd.print(Runkown);
+
+  delay(250);
+}


### PR DESCRIPTION
feat: Add Ohmmeter Sketch

- Incorporate the 'LiquidCrystal' library to streamline the LCD interface.
- Initialize the LCD object ('lcd') with the necessary pin assignments.
- Declare key constants and variables for enhanced readability:
  - 'VpPin' is assigned to analog pin A0 for voltage measurement.
  - 'Vin' is set to 5V, representing the input voltage.
  - 'Vout' holds the calculated output voltage.
  - 'Rknown' is defined as 3900 ohms, representing a known reference resistor.
  - 'Runkown' stores the calculated value of the unknown resistor.

In the 'setup' function:
- Establish serial communication at a baud rate of 9600.
- Initialize the LCD as a 16x2 display.

Within the 'loop' function:
- Clear the LCD display to ensure a clean slate.
- Measure voltage Vp, convert it to voltage ('Vout'), and display it.
- Calculate the value of the unknown resistor ('Runkown') and display it alongside 'R = '.
- Introduced a 250-millisecond delay for looping.